### PR TITLE
Add image build test action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Docker Image build
+
+on:
+  push:
+    branches:
+      - 'dev'
+  pull_request:
+    branches:
+      - 'main'
+      - 'dev'
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          tags: imgios/nonnatittina-bot:latest


### PR DESCRIPTION
This action just build the Docker Image and can be used as test maybe to validate the Dockerfile, indeed the action is triggered each time a new commit is pushed in the `dev` branch or a new pull request is created having `dev` or `main` as base.